### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ then use or require it
 ```
 (ns my-ns 
   ;; ...
-  [:use datac.core])
+  (:require [datac.core :refer :all]))
+($> inc {:a 1 :b 2}) ;=> {:a 2, :b 3}
 ```
 
 ### Feedback 


### PR DESCRIPTION
The use of (:use ...) is discouraged in favor of (:require [foo :refer :all])

Also, it is encouraged inside (ns ...) to put parens around the different :require, :import, square brackets around libspecs (and parens around :refer lists, but there's no example here)
